### PR TITLE
Switch from catppuccin to batppuccin theme

### DIFF
--- a/init.el
+++ b/init.el
@@ -1945,7 +1945,9 @@ When 'quit' is set, quits window when any other key is pressed."
     (add-hook 'project-switch-project-hook #'t--persp-switch-to-project)))
 
 ;;; themes
-(t-package catppuccin-theme gh "catppuccin/emacs" "4544014" nil)
+(t-package batppuccin-mocha-theme gh "bbatsov/batppuccin-emacs" "492b657" nil
+  :config
+  (load-theme 'batppuccin-mocha t))
 (t-package doric-themes gh "protesilaos/doric-themes" "86a3b91" nil
   :init
   (setq doric-themes-to-toggle '(doric-fire doric-water)


### PR DESCRIPTION
Replaces `catppuccin-theme` (catppuccin/emacs) with `batppuccin-mocha-theme` from [bbatsov/batppuccin-emacs](https://github.com/bbatsov/batppuccin-emacs) — batsov's opinionated Emacs take on Catppuccin.

## Changes

- Swaps the `t-package` entry to point at `bbatsov/batppuccin-emacs` pinned to latest SHA `492b657`
- Adds a `:config` block with `(load-theme 'batppuccin-mocha t)` to activate the theme on load (the old catppuccin entry had no activation)

## Reference

https://batsov.com/articles/2026/03/29/batppuccin-my-take-on-catppuccin-for-emacs/