### PR TITLE
Add config snippets from emacsredux "Stealing from the Best"

### DIFF
--- a/init.el
+++ b/init.el
@@ -923,6 +923,12 @@ When 'quit' is set, quits window when any other key is pressed."
       (auth-source-forget-all-cached))
     (apply 'auth-source-pick-first-password args)))
 
+;;; kill ring
+;; save external clipboard content into the kill ring before overwriting it.
+(setq save-interprogram-paste-before-kill t)
+;; don't clutter the kill ring with identical entries from repeated kills.
+(setq kill-do-not-save-duplicates t)
+
 ;;; default binds
 (keymap-set global-map "s-a" #'mark-whole-buffer)
 (keymap-set global-map "s-c" #'kill-ring-save)
@@ -1073,8 +1079,20 @@ When 'quit' is set, quits window when any other key is pressed."
 (setq auto-window-vscroll nil)
 (setq scroll-preserve-screen-position t)
 
+;; disable bidirectional display reordering for LTR-only text; big perf win in large files.
+(setq-default bidi-display-reordering 'left-to-right
+              bidi-paragraph-direction 'left-to-right)
+(setq bidi-inhibit-bpa t)
+
+;; don't draw a cursor or paint selections in windows that aren't focused.
+(setq cursor-in-non-selected-windows nil)
+(setq highlight-nonselected-windows nil)
+
 ;; reduce lag while typing in large buffers.
 (setq redisplay-skip-fontification-on-input t)
+
+;; defer syntax highlighting until you stop typing, avoiding mid-keystroke stutter.
+(setq jit-lock-defer-time 0)
 
 ;; no backups, lockfiles, or autosave files.
 (setq make-backup-files nil)
@@ -1896,6 +1914,9 @@ When 'quit' is set, quits window when any other key is pressed."
   :config
   (add-hook 'compilation-filter-hook #'ansi-color-compilation-filter))
 
+;; automatically chmod +x any saved file that starts with a shebang line.
+(add-hook 'after-save-hook #'executable-make-buffer-file-executable-if-script-p)
+
 ;;; highlight TODO
 (t-package hl-todo gh "tarsius/hl-todo" "9540fc4" nil
   :config
@@ -2204,7 +2225,9 @@ When 'quit' is set, quits window when any other key is pressed."
 (use-package savehist
   :init
   ;; Persist minibuffer history for Vertico and other completions.
-  (savehist-mode))
+  (savehist-mode)
+  ;; also persist the kill ring so clipboard history survives Emacs restarts.
+  (setq savehist-additional-variables '(kill-ring search-ring regexp-search-ring)))
 
 ;;; window undo redo
 (use-package winner
@@ -2441,6 +2464,9 @@ words of the candidate, respectively."
 
 ;;; eglot
 (use-package eglot)
+
+;; default read buffer is 64KB; LSP servers routinely send multi-MB responses.
+(setq read-process-output-max (* 4 1024 1024))
 
 (after! eglot
   (setq eglot-connect-timeout (* 60 20)


### PR DESCRIPTION
Incorporates the nuggets from https://emacsredux.com/blog/2026/04/07/stealing-from-the-best-emacs-configs/, placed near related existing config.

## Changes

**`;;; init tweaks` — display/performance block** (next to existing scrolling + fontification settings)
- `bidi-display-reordering` / `bidi-paragraph-direction` / `bidi-inhibit-bpa` — disables bidirectional text reordering for LTR-only buffers, big perf win in large files
- `cursor-in-non-selected-windows nil` / `highlight-nonselected-windows nil` — stops Emacs drawing cursors and painting selections in windows you're not looking at
- `jit-lock-defer-time 0` — defers syntax highlighting until you stop typing, eliminating mid-keystroke stutter

**`;;; kill ring`** (new section, before `;;; default binds`)
- `save-interprogram-paste-before-kill t` — saves external clipboard into the kill ring before overwriting, so you don't lose what you copied from the browser
- `kill-do-not-save-duplicates t` — deduplicates the kill ring when the same text is killed repeatedly

**`;;; minibuffer history vertico` — savehist block**
- `savehist-additional-variables` with `kill-ring` — persists kill ring across restarts, giving you clipboard history that survives quitting Emacs

**After `;;; compilation`**
- `executable-make-buffer-file-executable-if-script-p` after-save hook — automatically `chmod +x` any file saved with a shebang line

**`;;; eglot`**
- `read-process-output-max` bumped to 4 MB — the default 64 KB is too small for LSP servers that routinely send large responses